### PR TITLE
Set default MIDI instruments for each voice

### DIFF
--- a/includes/global-variables.ily
+++ b/includes/global-variables.ily
@@ -11,3 +11,11 @@ fermataUnderBarline = {
   \tweak direction #DOWN
   \textEndMark \markup { \musicglyph "scripts.dfermata" }
 }
+
+upperMidiInstrument = {
+  \set Staff.midiInstrument = #"acoustic grand"
+}
+
+lowerMidiInstrument = {
+  \set Staff.midiInstrument = #"acoustic grand"
+}

--- a/includes/invention-no1-C-maj-parts.ily
+++ b/includes/invention-no1-C-maj-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -98,8 +99,8 @@ inventionOneMidi =
   }
   \articulate <<
     <<
-      \new Staff = "upper" \rightHand
-      \new Staff = "lower" \leftHand
+      \new Staff = "upper" { \upperMidiInstrument \rightHand }
+      \new Staff = "lower" { \lowerMidiInstrument \leftHand }
     >>
   >>
   \midi {

--- a/includes/invention-no10-G-maj-parts.ily
+++ b/includes/invention-no10-G-maj-parts.ily
@@ -137,8 +137,8 @@ inventionTenMidi =
   \articulate <<
     \keepWithTag midi
     <<
-      \new Staff = "upper" \rightHand
-      \new Staff = "lower" \leftHand
+      \new Staff = "upper" { \upperMidiInstrument \rightHand }
+      \new Staff = "lower" { \lowerMidiInstrument \leftHand }
     >>
   >>
   \midi {

--- a/includes/invention-no11-G-min-parts.ily
+++ b/includes/invention-no11-G-min-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -105,8 +106,8 @@ inventionElevenMidi =
   \articulate {
     \keepWithTag midi
     <<
-      \new Staff = "upper" \rightHand
-      \new Staff = "lower" \leftHand
+      \new Staff = "upper" { \upperMidiInstrument \rightHand }
+      \new Staff = "lower" { \lowerMidiInstrument \leftHand }
     >>
   }
   \midi {

--- a/includes/invention-no12-A-maj-parts.ily
+++ b/includes/invention-no12-A-maj-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -110,8 +111,8 @@ inventionTwelveMidi =
   \articulate {
     \keepWithTag midi
     <<
-      \new Staff = "upper" \rightHand
-      \new Staff = "lower" \leftHand
+      \new Staff = "upper" { \upperMidiInstrument \rightHand }
+      \new Staff = "lower" { \lowerMidiInstrument \leftHand }
     >>
   }
   \midi {

--- a/includes/invention-no13-A-min-parts.ily
+++ b/includes/invention-no13-A-min-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -105,8 +106,8 @@ inventionThirteenMidi =
     midiOutputFile = "invention-no13-A-min" % see midi-title.ily
   }
   <<
-    \new Staff = "upper" \rightHand
-    \new Staff = "lower" \leftHand
+    \new Staff = "upper" { \upperMidiInstrument \rightHand }
+    \new Staff = "lower" { \lowerMidiInstrument \leftHand }
   >>
   \midi {
     \tempo 4 = 108

--- a/includes/invention-no14-Bb-maj-parts.ily
+++ b/includes/invention-no14-Bb-maj-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -92,8 +93,8 @@ inventionFourteenMidi =
     midiOutputFile = "invention-no14-Bb-maj" % see midi-title.ily
   }
   <<
-    \new Staff = "upper" \rightHand
-    \new Staff = "lower" \leftHand
+    \new Staff = "upper" { \upperMidiInstrument \rightHand }
+    \new Staff = "lower" { \lowerMidiInstrument \leftHand }
   >>
   \midi {
     \tempo 4 = 69

--- a/includes/invention-no15-B-min-parts.ily
+++ b/includes/invention-no15-B-min-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -103,8 +104,8 @@ inventionFifteenMidi =
   }
   \articulate {
     <<
-      \new Staff = "upper" \rightHand
-      \new Staff = "lower" \leftHand
+      \new Staff = "upper" { \upperMidiInstrument \rightHand }
+      \new Staff = "lower" { \lowerMidiInstrument \leftHand }
     >>
   }
   \midi {

--- a/includes/invention-no2-C-min-parts.ily
+++ b/includes/invention-no2-C-min-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -121,8 +122,8 @@ inventionTwoMidi =
   \articulate <<
     \keepWithTag midi
     <<
-      \new Staff = "upper" \rightHand
-      \new Staff = "lower" \leftHand
+      \new Staff = "upper" { \upperMidiInstrument \rightHand }
+      \new Staff = "lower" { \lowerMidiInstrument \leftHand }
     >>
   >>
   \midi {

--- a/includes/invention-no3-D-maj-parts.ily
+++ b/includes/invention-no3-D-maj-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -220,8 +221,8 @@ inventionThreeMidi =
   }
   \articulate <<
     <<
-      \new Staff = "upper" << \rightHand \dynamics >>
-      \new Staff = "lower" << \leftHand \dynamics >>
+      \new Staff = "upper" << \upperMidiInstrument \rightHand \dynamics >>
+      \new Staff = "lower" << \lowerMidiInstrument \leftHand \dynamics >>
     >>
   >>
   \midi {

--- a/includes/invention-no4-D-min-parts.ily
+++ b/includes/invention-no4-D-min-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -191,8 +192,8 @@ inventionFourMidi =
   \articulate <<
     \keepWithTag midi
     <<
-      \new Staff = "upper" \rightHand
-      \new Staff = "lower" \leftHand
+      \new Staff = "upper" { \upperMidiInstrument \rightHand }
+      \new Staff = "lower" { \lowerMidiInstrument \leftHand }
     >>
   >>
   \midi {

--- a/includes/invention-no5-Eb-maj-parts.ily
+++ b/includes/invention-no5-Eb-maj-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -130,8 +131,8 @@ inventionFiveMidi =
   \articulate <<
     \keepWithTag midi
     <<
-      \new Staff = "upper" \rightHand
-      \new Staff = "lower" \leftHand
+      \new Staff = "upper" { \upperMidiInstrument \rightHand }
+      \new Staff = "lower" { \lowerMidiInstrument \leftHand }
     >>
   >>
   \midi {

--- a/includes/invention-no6-E-maj-parts.ily
+++ b/includes/invention-no6-E-maj-parts.ily
@@ -205,8 +205,8 @@ inventionSixMidi =
     midiOutputFile = "invention-no6-E-maj" % see midi-title.ily
   }
   <<
-    \new Staff = "upper" \rightHand
-    \new Staff = "lower" \leftHand
+    \new Staff = "upper" { \upperMidiInstrument \rightHand }
+    \new Staff = "lower" { \lowerMidiInstrument \leftHand }
   >>
   \midi {
     \tempo 8 = 104

--- a/includes/invention-no7-E-min-parts.ily
+++ b/includes/invention-no7-E-min-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -124,8 +125,8 @@ inventionSevenMidi =
   \articulate <<
     \keepWithTag midi
     <<
-      \new Staff = "upper" \rightHand
-      \new Staff = "lower" \leftHand
+      \new Staff = "upper" { \upperMidiInstrument \rightHand }
+      \new Staff = "lower" { \lowerMidiInstrument \leftHand }
     >>
   >>
   \midi {

--- a/includes/invention-no8-F-maj-parts.ily
+++ b/includes/invention-no8-F-maj-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -126,8 +127,8 @@ inventionEightMidi =
     midiOutputFile = "invention-no8-F-maj" % see midi-title.ily
   }
   <<
-    \new Staff = "upper" \rightHand
-    \new Staff = "lower" \leftHand
+    \new Staff = "upper" { \upperMidiInstrument \rightHand }
+    \new Staff = "lower" { \lowerMidiInstrument \leftHand }
   >>
   \midi {
     \tempo 4 = 120

--- a/includes/invention-no9-F-min-parts.ily
+++ b/includes/invention-no9-F-min-parts.ily
@@ -3,6 +3,7 @@
 \version "2.24.0"
 \language "english"
 
+\include "global-variables.ily"
 \include "midi-title.ily"
 
 global = {
@@ -134,8 +135,8 @@ inventionNineMidi =
   }
   \keepWithTag midi
   <<
-    \new Staff = "upper" \rightHand
-    \new Staff = "lower" \leftHand
+    \new Staff = "upper" { \upperMidiInstrument \rightHand }
+    \new Staff = "lower" { \lowerMidiInstrument \leftHand }
   >>
   \midi {
     \tempo 4 = 72


### PR DESCRIPTION
Analogous to the change I made to the bach-15-sinfonias edition, make the MIDI instruments for both voices easily configurable in global-variables.ily, and set the default instruments to be "acoustic grand".

This configurability is useful for experimenting with different arrangements, learning each part individually, and other applications.